### PR TITLE
Fix moviepy import error

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ This project creates themed videos automatically using text, images, and audio f
    ```bash
    pip install -r requirements.txt
    ```
+   The `requirements.txt` pins `moviepy` to version `1.0.3` to avoid
+   import errors with older releases.
 
 ## Usage
 Run the bot from the repository root:

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ requests
 beautifulsoup4
 openai
 pydub
-moviepy
+moviepy==1.0.3
 Pillow
 google-cloud-texttospeech


### PR DESCRIPTION
## Summary
- pin moviepy version to avoid `concatenate_videoclips` import issue
- note pinned version in the README

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_68544502ec9c832db2d514b9f23b1ae8